### PR TITLE
feat(diagnostic): add diagnostic to node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
              tf
              message_generation
              message_runtime
+             diagnostic_updater
              )
 
 #######################################

--- a/launch/camera.launch
+++ b/launch/camera.launch
@@ -13,6 +13,7 @@
   <arg name="frame_id_base" default="$(arg ns)/$(arg nn)" />
   <arg name="respawn" default="true"/>
   <arg name="assume_sw_triggered" default="false"/>
+  <arg name="diagnostic_period" default="5"/>
 
   <!-- TODO: Consider removing the group tag and let the includer determine the
       namespace using a group. -->
@@ -30,6 +31,7 @@
       <param name="publish_viz_images" value="$(arg publish_viz_images)"/>
       <param name="frame_id_base" value="$(arg frame_id_base)" />
       <param name="assume_sw_triggered" value="$(arg assume_sw_triggered)"/>
+      <param name="diagnostic_period" value="$(arg diagnostic_period)"/>
 
       <!-- if assume_sw_triggered == True -->
       <param name="timeout_millis" value="500"

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>message_generation</depend>
+  <depend>diagnostic_updater</depend>
 
   <test_depend>rostest</test_depend>
 


### PR DESCRIPTION
Adds frequency monitoring to depth cloud publisher. By default it will publish updates every 5s. If the frequency of the point cloud is below 1 hz it is defined as an ERROR.

Related to JC-342